### PR TITLE
Allow onReceive to be overridden.

### DIFF
--- a/fliclib/src/main/java/io/flic/lib/FlicBroadcastReceiver.java
+++ b/fliclib/src/main/java/io/flic/lib/FlicBroadcastReceiver.java
@@ -14,7 +14,7 @@ import android.util.Log;
 public abstract class FlicBroadcastReceiver extends BroadcastReceiver {
 	private static final String TAG = "FlicBroadcastReceiver";
 
-	public final void onReceive(final Context context, final Intent intent) {
+	public void onReceive(final Context context, final Intent intent) {
 		if (!FlicManager.hasSetAppCredentials()) {
 			onRequestAppCredentials(context);
 		}


### PR DESCRIPTION
The main cause for this is that FlicManager.getInstance can
throw a couple of runtime exceptions, amongst them
AppCredentialsNotProvidedException and FlicAppNotInstalledException
which if not caught will crash the app.
This allows the concrete broadcast to catch and process these exceptions,
without crashing the app.

(Another option would be to handle the exceptions in the FlicLib. But for our project we actually want to handle the exceptions ourselves.)

In general a more preferred option would be to not provide this as a class inheriting from BroadcastReceiver but instead provide a BroadcastHandler class, which accepted a callback interface.